### PR TITLE
Corrected/amended some definitions, added more vocabulary

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -111,6 +111,7 @@ Object Oriented Programming (OOP) | オブジェクト指向 | オブジェク�
 Functional Programming (FP) | 関数型プログラミング | かんすうがたプログラミング |
 Artificial Intelligence (AI) | 人工知能 | じんこうちのう |
 Optimization (optimize) | 最適化（する）| さいてきか（する）|
+Revision number (git, application) | 版数 | はんすう |
 
 
 ### Security

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -111,7 +111,7 @@ Object Oriented Programming (OOP) | オブジェクト指向 | オブジェク�
 Functional Programming (FP) | 関数型プログラミング | かんすうがたプログラミング |
 Artificial Intelligence (AI) | 人工知能 | じんこうちのう |
 Optimization (to optimize) | 最適化（する）| さいてきか（する）|
-Revision number (git, application) | 版数 | はんすう |
+Revision number (git, application) | リビジョン番号 | リビジオン番号 |
 To process | 処理（する）| しょり（する）|
 
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -112,6 +112,7 @@ Functional Programming (FP) | 関数型プログラミング | かんすうが�
 Artificial Intelligence (AI) | 人工知能 | じんこうちのう |
 Optimization (to optimize) | 最適化（する）| さいてきか（する）|
 Revision number (git, application) | 版数 | はんすう |
+To process | 処理（する）| しょり（する）|
 
 
 ### Security

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -88,7 +88,7 @@ Developer | 開発者 | かいはつしゃ |
 Development department | 開発部 | かいはつぶ |
 Research and development, R&D | 開発研究 | けんきゅうかいはつ
 Implementation | 実装 | じっそう |
-Design | 設計 | せっけい | Of code, infrastructure and systems, graphic design, etc.
+Design | 設計 | せっけい | Of code, infrastructure and systems, etc.
 Feature | 機能 | きのう |
 Execution | 実行 | じっこう | Of a function or program
 Structure | 仕組み | しくみ | Eg. of code

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -161,7 +161,7 @@ English | Japanese | Kana | Notes
 Sales / Business | 営業 | えいぎょう |
 Salesperson | 営業者 | えいぎょうしゃ |
 Executive, company official | 役員 | やくいん |
-Chief technical officer | 最後技術責任者 | さいごぎじゅつせきにんしゃ |
+Chief technical officer | 最高技術責任者 | さいこうぎじゅつせきにんしゃ |
 Our company | 弊社 | へいしゃ |
 Your company | 御社 | おんしゃ |
 Office | 事務所 | じむしょ |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -65,7 +65,7 @@ To display | 表示（する） | ひょうじ |
 
 English | Japanese | Kana | Notes
 --------|----------|------|------
-Device, terminal | 端末 | たんまつ | Often used to mean smartphones and tablets, but can also mean command-line
+Device, terminal | 端末 | たんまつ | smartphones, tablets, e-readers, command-line interfaces, etc
 Japanese feature phone | ガラ携 | ガラけい | From ガラパゴス携帯電話
 Smartphone | スマホ / スマートフォン | |
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -135,7 +135,6 @@ Server | サーバ / サーバー | |
 Physical server | 物理サーバ | ぶつりサーバ |
 Virtual server | 仮想マシン・仮想サーバ | かそうマシン・かそうサーバ | Machine tends to be favoured in most openly available technical documentations (ie. VMWare, etc)
 Server layout / architecture | サーバ構成 | サーバこうせい |
-Hierarchical computer network | 階層計算機ネットワーク | かいそうけいさんきネットワーク | Rarely used
 Static IP | 固定IP | こていIP |
 Load | 負荷 | ふか |
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -159,7 +159,6 @@ Manager | 管理者 | かんりしゃ |
 English | Japanese | Kana | Notes
 --------|----------|------|------
 Sales / Business | 営業 | えいぎょう |
-Salesperson | 営業者 | えいぎょうしゃ |
 Executive, company official | 役員 | やくいん |
 Chief technical officer | 最高技術責任者 | さいこうぎじゅつせきにんしゃ |
 Our company | 弊社 | へいしゃ |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -43,6 +43,7 @@ guidelines though, to keep things consistent and avoid it exploding into a copy 
 English | Japanese | Kana | Notes
 --------|----------|------|------
 Computer | コンピュータ / コンピューター |
+Personal computer, PC | パソコン | パソコン |
 User | ユーザ / ユーザー |
 Settings | 設定 | せってい |
 Configuration | 構成 | こうせい |
@@ -64,7 +65,7 @@ To display | 表示（する） | ひょうじ |
 
 English | Japanese | Kana | Notes
 --------|----------|------|------
-Device | 端末 | たんまつ | Usually smartphones and tablets
+Device, terminal | 端末 | たんまつ | Often used to mean smartphones and tablets, but can also mean command-line
 Japanese feature phone | ガラ携 | ガラけい | From ガラパゴス携帯電話
 Smartphone | スマホ / スマートフォン | |
 
@@ -85,7 +86,9 @@ English | Japanese | Kana | Notes
 Development | 開発 | かいはつ |
 Developer | 開発者 | かいはつしゃ |
 Development department | 開発部 | かいはつぶ |
+Research and development, R&D | 開発研究 |
 Implementation | 実装 | じっそう |
+Design | 設計 | せっけい | Can be loosely used as architecture, also used in other branches of engineering
 Feature | 機能 | きのう |
 Execution | 実行 | じっこう | Of a function or program
 Structure | 仕組み | しくみ | Eg. of code
@@ -106,6 +109,8 @@ To select | 選択（する） | せんたく |
 To search | 検索（する） | けんさく |
 Object Oriented Programming (OOP) | オブジェクト指向 | オブジェクトしこう |
 Functional Programming (FP) | 関数型プログラミング | かんすうがたプログラミング |
+Artificial Intelligence (AI) | 人工知能 | じんこうちのう |
+Optimization (optimize) | 最適化（する）| さいてきか（する）|
 
 
 ### Security
@@ -127,8 +132,9 @@ English | Japanese | Kana | Notes
 --------|----------|------|------
 Server | サーバ / サーバー | |
 Physical server | 物理サーバ | ぶつりサーバ |
-Virtual server | 仮想サーバ | かそうサーバ |
+Virtual server | 仮想マシン・仮想サーバ | かそうマシン・かそうサーバ | Machine tends to be favoured in most openly available technical documentations (ie. VMWare, etc)
 Server layout / architecture | サーバ構成 | サーバこうせい |
+Hierarchical computer network | 階層計算機ネットワーク | かいそうけいさんきネットワーク | Rarely used
 Static IP | 固定IP | こていIP |
 Load | 負荷 | ふか |
 
@@ -144,6 +150,7 @@ Beta version | ベータ版 | ベータばん |
 Closed beta | クローズドベータ | |
 Front-end | フロントエンド | |
 Management | 管理 | かんり | Of people, software, etc
+Manager | 管理者 | かんりしゃ |
 
 
 ### Business
@@ -151,6 +158,9 @@ Management | 管理 | かんり | Of people, software, etc
 English | Japanese | Kana | Notes
 --------|----------|------|------
 Sales / Business | 営業 | えいぎょう |
+Salesperson | 営業者 | えいぎょうしゃ |
+Executive, company official | 役員 | やくいん |
+Chief technical officer | 最後技術責任者 | さいごぎじゅつせきにんしゃ |
 Our company | 弊社 | へいしゃ |
 Your company | 御社 | おんしゃ |
 Office | 事務所 | じむしょ |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -134,7 +134,8 @@ English | Japanese | Kana | Notes
 --------|----------|------|------
 Server | サーバ / サーバー | |
 Physical server | 物理サーバ | ぶつりサーバ |
-Virtual server | 仮想マシン・仮想サーバ | かそうマシン・かそうサーバ | Machine tends to be favoured in most openly available technical documentations (ie. VMWare, etc)
+Virtual machine | 仮想マシン | かそうマシン・ |
+Virtual server  | 仮想サーバ | かそうサーバ |
 Server layout / architecture | サーバ構成 | サーバこうせい |
 Static IP | 固定IP | こていIP |
 Load | 負荷 | ふか |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -86,7 +86,7 @@ English | Japanese | Kana | Notes
 Development | 開発 | かいはつ |
 Developer | 開発者 | かいはつしゃ |
 Development department | 開発部 | かいはつぶ |
-Research and development, R&D | 開発研究 |
+Research and development, R&D | 開発研究 | けんきゅうかいはつ
 Implementation | 実装 | じっそう |
 Design | 設計 | せっけい | Can be loosely used as architecture, also used in other branches of engineering
 Feature | 機能 | きのう |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -88,7 +88,7 @@ Developer | 開発者 | かいはつしゃ |
 Development department | 開発部 | かいはつぶ |
 Research and development, R&D | 開発研究 | けんきゅうかいはつ
 Implementation | 実装 | じっそう |
-Design | 設計 | せっけい | Can be loosely used as architecture, also used in other branches of engineering
+Design | 設計 | せっけい | Of code, infrastructure and systems, graphic design, etc.
 Feature | 機能 | きのう |
 Execution | 実行 | じっこう | Of a function or program
 Structure | 仕組み | しくみ | Eg. of code

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -43,7 +43,7 @@ guidelines though, to keep things consistent and avoid it exploding into a copy 
 English | Japanese | Kana | Notes
 --------|----------|------|------
 Computer | コンピュータ / コンピューター |
-Personal computer, PC | パソコン | パソコン |
+Personal computer, PC | パソコン |
 User | ユーザ / ユーザー |
 Settings | 設定 | せってい |
 Configuration | 構成 | こうせい |
@@ -110,7 +110,7 @@ To search | 検索（する） | けんさく |
 Object Oriented Programming (OOP) | オブジェクト指向 | オブジェクトしこう |
 Functional Programming (FP) | 関数型プログラミング | かんすうがたプログラミング |
 Artificial Intelligence (AI) | 人工知能 | じんこうちのう |
-Optimization (optimize) | 最適化（する）| さいてきか（する）|
+Optimization (to optimize) | 最適化（する）| さいてきか（する）|
 Revision number (git, application) | 版数 | はんすう |
 
 


### PR DESCRIPTION
Noteworthy:

- 端末　actually means terminal, and can be used to mean command-line terminal, etc.
- コンピュータ　isn't so widely used; most Japaneses would use パソコン or サーバー to describe respectively PC and server, and use 計算機 in academic lingo (abbreviation of 電子計算機)
- 仮想マシン tends to be favoured to 仮想サーバー in much of the technical documentation published by vendors.

Added some additional lingo as well, not all very common lingo, but the stuff I could think of basically.