### PR TITLE
Added the word 'cell phone' with its informal abbreviation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -87,6 +87,7 @@ To copy and paste | コピペ（する） | |
 English | Japanese | Kana | Notes
 --------|----------|------|------
 Device, terminal | 端末 | たんまつ | Smartphones, tablets, e-readers, command-line interfaces, etc
+Cell phone | ケータイ / 携帯電話　| けいたいでんわ | standard (non-smartphone) cell phone　
 Japanese feature phone | ガラ携 | ガラけい | From ガラパゴス携帯電話
 Tablet-PC | タブＰＣ / タブレットＰＣ |  | 
 Smartphone | スマホ / スマートフォン | |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -87,7 +87,7 @@ To copy and paste | コピペ（する） | |
 English | Japanese | Kana | Notes
 --------|----------|------|------
 Device, terminal | 端末 | たんまつ | Smartphones, tablets, e-readers, command-line interfaces, etc
-Cell phone | ケータイ / 携帯電話　| けいたいでんわ | standard (non-smartphone) cell phone　
+Cell Phone | 携帯電話 / 携帯 | けいたいでんわ / ケータイ | The latter is an (informal) abbreviation commonly used
 Japanese feature phone | ガラ携 | ガラけい | From ガラパゴス携帯電話
 Tablet-PC | タブＰＣ / タブレットＰＣ |  | 
 Smartphone | スマホ / スマートフォン | |


### PR DESCRIPTION
I was surprised this wasn't in the list yet. It is still the most used word for a cell phone I hear from Japanese people, even for smartphones (it's the same here in Germany).

Note that I went for the `タブPC　/  タブレットPC` version for the abbreviation (which is used a lot more often, than the regular `懈怠電話（けいたいでんわ）`.  Not like I did with `Screenshot`, where I made two entries.
I did this to keep it consistent with the other vocabularies in the `Device` section.